### PR TITLE
new confSummary file location

### DIFF
--- a/python/almanac/apogee.py
+++ b/python/almanac/apogee.py
@@ -122,7 +122,24 @@ def get_plate_targets(plate_id):
 
 # get FPS plug info
 def get_confSummary_path(observatory, config_id):
-    return f"{SDSSCORE_DIR}/{observatory}/summary_files/{str(config_id)[:-2].zfill(4)}XX/confSummary-{config_id}.par"
+    print("get_confSummary_path", observatory, config_id)
+    # we want the confSummaryFS file. The F means that is has the actual robot positions measured
+    # measured by the field view camera. The S means that that it has Jose's estimate of whether
+    # unassigned APOGEE fibers can be used as sky.
+
+    # config_ids are left-padded to 6 digits and foldered by the first 3 and first 4 digits.
+    # the final file name does not used the padded config_id
+    # For example config_id 1838 is in summary_files/001XXX/0018XX/confSummaryFS-1838.par
+    c = str(config_id)
+    directory = f"{SDSSCORE_DIR}/{observatory}/summary_files/{c[:-3].zfill(3)}XXX/{c[:-2].zfill(4)}XX/"
+
+    # fall back to confSummary if confSummaryFS does not exist
+    path = f"{directory}/confSummaryFS-{config_id}.par"
+    if not os.path.exists(path):
+        path = f"{directory}/confSummary-{config_id}.par"
+
+    return path
+
     
 def get_fps_targets(observatory, config_id):
     lkeys = "_, positionerId, holeId, fiberType, assigned, on_target, valid, decollided, xwok, ywok, zwok, xFocal, yFocal, alpha, beta, racat,  deccat, pmra, pmdex, parallax, ra, dec, lambda_eff, coord_epoch, spectrographId, fiberId".split(", ")

--- a/python/almanac/apogee.py
+++ b/python/almanac/apogee.py
@@ -122,7 +122,6 @@ def get_plate_targets(plate_id):
 
 # get FPS plug info
 def get_confSummary_path(observatory, config_id):
-    print("get_confSummary_path", observatory, config_id)
     # we want the confSummaryFS file. The F means that is has the actual robot positions measured
     # measured by the field view camera. The S means that that it has Jose's estimate of whether
     # unassigned APOGEE fibers can be used as sky.
@@ -137,6 +136,7 @@ def get_confSummary_path(observatory, config_id):
     path = f"{directory}/confSummaryFS-{config_id}.par"
     if not os.path.exists(path):
         path = f"{directory}/confSummary-{config_id}.par"
+    print("confSummary(FS) path: ", path)
 
     return path
 
@@ -245,6 +245,9 @@ def get_almanac_data(observatory: str, mjd: int, fibers=False, xmatch=True, prof
     if fibers:
         configids = set(exposures["configid"]).difference({"", "-1", "-999"})
         plateids = set(exposures["plateid"]).difference({"", "0", "-1"}) # plate ids often 0
+        # make sure neither set contains None
+        configids.discard(None)
+        plateids.discard(None)
         
         if (plateids or configids) and xmatch:
             try:

--- a/python/almanac/io.py
+++ b/python/almanac/io.py
@@ -25,6 +25,13 @@ def _update_almanac(fp, exposures, sequence_indices, fiber_maps, compression=Tru
     group = get_or_create_group(fp, f"{observatory}/{mjd}")
     
     delete_hdf5_entry(group, "exposures")
+
+    # if any cols are all None, drop them. They will cause write_table_hdf5 to fail.
+    for col in exposures.dtype.names:
+        if all(o is None for o in exposures[col]):
+            print(f"Dropping column {col} from exposures table because it is all None")
+            exposures.remove_columns([col])
+
     write_table_hdf5(exposures, group, "exposures", compression=compression)
     
     _print(f"\t{observatory}")

--- a/python/almanac/io.py
+++ b/python/almanac/io.py
@@ -59,10 +59,11 @@ def _update_almanac(fp, exposures, sequence_indices, fiber_maps, compression=Tru
         for refid, targets in mapping.items():                
             g = get_or_create_group(group, f"fibers/{fiber_type}")
             delete_hdf5_entry(group, f"fibers/{fiber_type}/{refid}")
+
             write_table_hdf5(
                 targets,
                 g,
-                refid,
+                path=refid,
                 compression=compression,
             )             
                             
@@ -70,7 +71,6 @@ def _update_almanac(fp, exposures, sequence_indices, fiber_maps, compression=Tru
         
 
 def write_almanac(output, results, **kwargs):
-    
     with h5.File(output, "a") as fp:
         for args in tqdm(results, desc=f"Updating {output}"):
             _update_almanac(fp, *args, **kwargs)


### PR DESCRIPTION
The way that the fiber assignment info (? I think this is the right way to describe it) is recorded has changed, which means that the info isn't getting propagated to ApogeeReduction.jl.

This pulls the new table from the right location, but it's not complete in the sense that the data now has a different format, and thus, so does the almanac output file.