### PR TITLE
Insert missing exposures that we expected

### DIFF
--- a/bin/almanac
+++ b/bin/almanac
@@ -23,18 +23,16 @@ def main(verbosity, mjd, mjd_start, mjd_end, date, date_start, date_end, apo, lc
     The almanac extracts metadata from raw APOGEE exposures (including fiber mappings)
     and finds sequences of exposures that form individual visits.
     """    
-    
-    if output is None and verbosity == 0:
-        click.echo("No output file specified. Increasing verbosity to print to stdout.")
-        verbosity = 2
-        
+
     from tqdm import tqdm
     from itertools import product
-
     from almanac import (apogee, io, utils)
 
     tqdm_kwds = dict(disable=(verbosity < 1))
 
+    if output is None and verbosity == 0:
+        verbosity = 2
+        
     show_exposure_columns = exposure_columns.split(",")
     show_fps_columns = fps_columns.split(",")
     show_plate_columns = plate_columns.split(",")

--- a/bin/almanac
+++ b/bin/almanac
@@ -32,7 +32,6 @@ def main(verbosity, mjd, mjd_start, mjd_end, date, date_start, date_end, apo, lc
     from itertools import product
 
     from almanac import (apogee, io, utils)
-    print(apogee.__file__)
 
     tqdm_kwds = dict(disable=(verbosity < 1))
 

--- a/python/almanac/utils.py
+++ b/python/almanac/utils.py
@@ -70,7 +70,13 @@ def pretty_print_targets(targets, fiber_type, refid, header_color="lightcyan", i
     print("\n")    
 
 
-def pretty_print_exposures(table, sequence_indices=None, header_color="lightcyan", sequence_colors=("lightgreen", "yellow")):
+def pretty_print_exposures(
+        table, 
+        sequence_indices=None, 
+        header_color="lightcyan", 
+        sequence_colors=("lightgreen", "yellow"),
+        missing_color="red",
+    ):
     
     observatory, mjd = table["observatory"][0], table["mjd"][0]
     color_print(f"{len(table)} exposures from {observatory.upper()} on MJD {mjd}:", header_color)
@@ -111,7 +117,10 @@ def pretty_print_exposures(table, sequence_indices=None, header_color="lightcyan
             if in_sequence:
                 color_print(line, sequence_color)
             else:                     
-                print(line)
+                if line.find("Missing") > -1:
+                    color_print(line, missing_color)
+                else:
+                    print(line)
     
     color_print(lines[1], header_color)    
     print("\n")

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ package_dir =
 install_requires =
         numpy
 	astropy
-	hdf5
+	h5py
 	tqdm
 	click
 


### PR DESCRIPTION
When exposures are expected, but are not found, `almanac` will now insert dummy rows for those files and give them a fictitious image type of 'Missing'. An example of this is APO on MJD 60754 where exposures 69 and 70 are missing due to an instrument error. The non-contiguous nature of the exposure numbers for that night caused subsequent pipelines to fail.

The missing exposures will be highlighted in the pretty print (eg see below):

<img width="693" alt="image" src="https://github.com/user-attachments/assets/0382dd75-3548-45bf-b7fb-e76765d58c15" />
