### PR TITLE
Added rank=1 constraint on sdss_id_flat

### DIFF
--- a/python/almanac/apogee.py
+++ b/python/almanac/apogee.py
@@ -349,7 +349,10 @@ def get_fps_fiber_maps(observatory, config_ids, xmatch=True):
                     SDSS_ID_flat.sdss_id,
                     SDSS_ID_flat.catalogid
                 )
-                .where((SDSS_ID_flat.catalogid.in_(tuple(catalogids)))&(SDSS_ID_flat.rank==1))
+                .where(
+                    SDSS_ID_flat.catalogid.in_(tuple(catalogids))
+                &   (SDSS_ID_flat.rank == 1)
+                )
                 .tuples()
             )
             sdss_id_lookup = {}

--- a/python/almanac/apogee.py
+++ b/python/almanac/apogee.py
@@ -349,7 +349,7 @@ def get_fps_fiber_maps(observatory, config_ids, xmatch=True):
                     SDSS_ID_flat.sdss_id,
                     SDSS_ID_flat.catalogid
                 )
-                .where(SDSS_ID_flat.catalogid.in_(tuple(catalogids)))
+                .where((SDSS_ID_flat.catalogid.in_(tuple(catalogids)))&(SDSS_ID_flat.rank==1))
                 .tuples()
             )
             sdss_id_lookup = {}


### PR DESCRIPTION
The expected behavior is that the peewee query produced unique catalogid <--> sdss_id pairs. However, this is only the case when including the constraint (rank==1) when querying sdss_id_flat. I added this to the query.

However, I didn't test run the code because I'm not familiar with what this package does. If somebody could test this, I'd really appreciate it.